### PR TITLE
fix entry point name to avoid collision

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,4 +43,4 @@ zip_safe = true
 
 [options.entry_points]
 colcon_core.package_identification =
-    python = colcon_python_setup_py.package_identification.python_setup_py:PythonPackageIdentification
+    python_setup_py = colcon_python_setup_py.package_identification.python_setup_py:PythonPackageIdentification


### PR DESCRIPTION
Connect to colcon/colcon-core#43.

The naming of the entry point collides with https://github.com/colcon/colcon-core/blob/ce10892696342ec482d9908a6bd94b3e138c2630/setup.cfg#L91.