### PR TITLE
use utf-8 to pass setup arguments from subprocess

### DIFF
--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -198,12 +198,13 @@ def get_setup_arguments_with_context(setup_py, env):
         "sys.path.insert(0, '%s')" % pkg_path,
         'from colcon_python_setup_py.package_identification.python_setup_py'
         ' import get_setup_arguments',
-        "print(repr(get_setup_arguments('%s')))" % setup_py]
+        "output = repr(get_setup_arguments('%s'))" % setup_py,
+        "sys.stdout.buffer.write(output.encode('utf-8'))"]
 
     # invoke get_setup_arguments() in a separate interpreter
     cmd = [sys.executable, '-c', ';'.join(code_lines)]
     result = subprocess.run(
         cmd, stdout=subprocess.PIPE, env=env, check=True)
-    output = result.stdout.decode()
+    output = result.stdout.decode('utf-8')
 
     return ast.literal_eval(output)


### PR DESCRIPTION
Aiming to address the problem reported in https://github.com/ros2/ros2/pull/748#issuecomment-516538309

Instead of relying on the default encoding of the platform force using `utf-8` since the logic controls both sides of the pipe.