### PR TITLE
Better scoping of things

### DIFF
--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -23,6 +23,7 @@ from colcon_core.plugin_system import satisfies_version
 
 from .run_setup_py import run_setup_py
 
+
 class PythonPackageIdentification(PackageIdentificationExtensionPoint):
     """Identify Python packages with `setup.py` files."""
 

--- a/colcon_python_setup_py/package_identification/run_setup_py.py
+++ b/colcon_python_setup_py/package_identification/run_setup_py.py
@@ -28,6 +28,13 @@ def run_setup_py(cwd, env, script_args=(), stop_after='run'):
     result = distutils.core.run_setup(
         'setup.py', script_args=script_args, stop_after=stop_after)
 
+    try:
+        # hack to make this class pickle to an ordinary set
+        from setuptools.extern.ordered_set import OrderedSet
+        OrderedSet.__reduce__ = lambda self: (set, (list(self),))
+    except ImportError:
+        pass
+
     return {
         key: value for key, value in result.__dict__.items()
         if (

--- a/colcon_python_setup_py/package_identification/run_setup_py.py
+++ b/colcon_python_setup_py/package_identification/run_setup_py.py
@@ -1,3 +1,6 @@
+# Copyright 2019 Rover Robotics via Dan Rose
+# Licensed under the Apache License, Version 2.0
+
 import distutils.core
 import os
 

--- a/colcon_python_setup_py/package_identification/run_setup_py.py
+++ b/colcon_python_setup_py/package_identification/run_setup_py.py
@@ -1,0 +1,41 @@
+import distutils.core
+import os
+
+
+def run_setup_py(cwd, env, script_args=(), stop_after='run'):
+    """
+    Modify the current process and run setup.py.
+
+    This should be run in a subprocess to not affect the state of the current
+    process.
+
+    :param str cwd: absolute path to a directory containing a setup.py script
+    :param dict env: environment variables to set before running setup.py
+    :param script_args: command-line arguments to pass to setup.py
+    :param stop_after: tells setup() when to stop processing
+    :returns: the public properties of a Distribution object, minus objects
+      with are generally not picklable
+    """
+    # need to be in setup.py's parent dir to detect any setup.cfg
+    os.chdir(cwd)
+
+    os.environ.clear()
+    os.environ.update(env)
+
+    result = distutils.core.run_setup(
+        'setup.py', script_args=script_args, stop_after=stop_after)
+
+    return {
+        key: value for key, value in result.__dict__.items()
+        if (
+            # Private properties
+            not key.startswith('_') and
+            # Getter methods
+            not callable(value) and
+            # Objects that are generally not picklable
+            key not in ('cmdclass', 'distclass', 'ext_modules') and
+            # These *seem* useful but always have the value 0.
+            # Look for their values in the 'metadata' object instead.
+            key not in result.display_option_names
+        )
+    }


### PR DESCRIPTION
1. Move dependency on setuptools closer to where it's needed
2. Scope multiprocessing Pool so a pool left open doesn't hang the process
3. Move run_setup_py to its own file so the subprocess doesn't need to import much

I think it would be nice for colcon to pass in a ProcessPoolExecutor that has a longer life, so we don't need to spin one up so often (the expensive part).