### PR TITLE
Make subprocess calls faster by not using ProcessPoolExecutor

### DIFF
--- a/colcon_python_setup_py/package_identification/out_of_process.py
+++ b/colcon_python_setup_py/package_identification/out_of_process.py
@@ -1,3 +1,6 @@
+# Copyright 2019 Rover Robotics via Dan Rose
+# Licensed under the Apache License, Version 2.0
+
 import functools
 import traceback
 

--- a/colcon_python_setup_py/package_identification/out_of_process.py
+++ b/colcon_python_setup_py/package_identification/out_of_process.py
@@ -1,0 +1,47 @@
+import functools
+import traceback
+
+
+class OutOfProcessError(RuntimeError):
+    """An exception raised from a different process"""
+
+    def __init__(self, description):
+        self.description = description
+
+    def __str__(self):
+        return self.description
+
+
+def out_of_process(fn):
+    """Decorator to wrap a function call in a subprocess"""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        import multiprocessing
+
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+
+        def target():
+            with child_conn:
+                try:
+                    result = fn(*args, **kwargs)
+                    child_conn.send((True, result))
+                except BaseException:
+                    child_conn.send((False, traceback.format_exc()))
+
+        with parent_conn:
+            p = multiprocessing.Process(
+                target=target,
+                daemon=True, name='out_of_process ' + fn.__name__
+            )
+            try:
+                p.start()
+                ok, value = parent_conn.recv()
+                if ok:
+                    return value
+                else:
+                    raise OutOfProcessError(value)
+            finally:
+                p.terminate()
+
+    return wrapper

--- a/colcon_python_setup_py/package_identification/out_of_process.py
+++ b/colcon_python_setup_py/package_identification/out_of_process.py
@@ -3,18 +3,32 @@ import traceback
 
 
 class OutOfProcessError(RuntimeError):
-    """An exception raised from a different process"""
+    """An exception raised from a different process."""
 
     def __init__(self, description):
+        """
+        Initialize self.
+
+        :param description: The full formatted exception
+        """
         self.description = description
 
     def __str__(self):
+        """Return str(self)."""
         return self.description
 
 
 def out_of_process(fn):
-    """Decorator to wrap a function call in a subprocess"""
+    """
+    Wrap a function in a subprocess.
 
+    Wrapped function will behave the same as the original function, except
+    it will run in a different process and exceptions will be wrapped in an
+    OutOfProcessError
+
+    :param fn: Function to run in a separate process
+    :return: Function that mimics `fn`.
+    """
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         import multiprocessing

--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from threading import Lock
 import traceback
+from typing import Mapping
 import warnings
 
 from colcon_core.package_identification \
@@ -239,12 +240,12 @@ def get_setup_arguments_with_context(setup_py, env):
 _process_pool = multiprocessing.Pool()
 
 
-def get_setup_information(setup_py, *, env):
+def get_setup_information(setup_py: Path, *, env: Mapping[str, str]):
     """
     Dry run the setup.py file and get the configuration information.
 
-    :param Path setup_py: path to a setup.py script
-    :param dict env: environment variables to set before running setup.py
+    :param setup_py: path to a setup.py script
+    :param env: environment variables to set before running setup.py
     :return: dictionary of data describing the package.
     :raise: RuntimeError if the setup script encountered an error
     """
@@ -253,7 +254,8 @@ def get_setup_information(setup_py, *, env):
             run_setup_py,
             kwds={
                 'cwd': os.path.abspath(str(setup_py.parent)),
-                'env': env,
+                # might be os.environ, which is not picklable
+                'env': dict(env),
                 'script_args': ('--dry-run',),
                 'stop_after': 'config'
             }

--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -23,6 +23,7 @@ from colcon_core.plugin_system import satisfies_version
 
 from .run_setup_py import run_setup_py
 
+
 class PythonPackageIdentification(PackageIdentificationExtensionPoint):
     """Identify Python packages with `setup.py` files."""
 

--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -257,4 +257,4 @@ def get_setup_information(setup_py: Path, *, env: Mapping[str, str]):
     except Exception as e:
         raise RuntimeError(
             "Failed to dry run setup script '{setup_py}': "
-                .format_map(locals()) + traceback.format_exc()) from e
+            .format_map(locals()) + traceback.format_exc()) from e

--- a/colcon_python_setup_py/package_identification/run_setup_py.py
+++ b/colcon_python_setup_py/package_identification/run_setup_py.py
@@ -28,6 +28,13 @@ def run_setup_py(cwd, env, script_args=(), stop_after='run'):
     result = distutils.core.run_setup(
         'setup.py', script_args=script_args, stop_after=stop_after)
 
+    try:
+        # hack to make this class pickle to an ordinary set
+        from setuptools.extern.ordered_set import OrderedSet
+        OrderedSet.__reduce__ = lambda self: (set, (list(self),))
+    except ImportError:
+        pass
+
     return {
         key: value for key, value in result.__dict__.items()
         if (

--- a/colcon_python_setup_py/package_identification/run_setup_py.py
+++ b/colcon_python_setup_py/package_identification/run_setup_py.py
@@ -1,3 +1,6 @@
+# Copyright 2019 Rover Robotics via Dan Rose
+# Licensed under the Apache License, Version 2.0
+
 import distutils.core
 import os
 

--- a/colcon_python_setup_py/package_identification/run_setup_py.py
+++ b/colcon_python_setup_py/package_identification/run_setup_py.py
@@ -1,0 +1,41 @@
+import distutils.core
+import os
+
+
+def run_setup_py(cwd, env, script_args=(), stop_after='run'):
+    """
+    Modify the current process and run setup.py.
+
+    This should be run in a subprocess to not affect the state of the current
+    process.
+
+    :param str cwd: absolute path to a directory containing a setup.py script
+    :param dict env: environment variables to set before running setup.py
+    :param script_args: command-line arguments to pass to setup.py
+    :param stop_after: tells setup() when to stop processing
+    :returns: the public properties of a Distribution object, minus objects
+      with are generally not picklable
+    """
+    # need to be in setup.py's parent dir to detect any setup.cfg
+    os.chdir(cwd)
+
+    os.environ.clear()
+    os.environ.update(env)
+
+    result = distutils.core.run_setup(
+        'setup.py', script_args=script_args, stop_after=stop_after)
+
+    return {
+        key: value for key, value in result.__dict__.items()
+        if (
+            # Private properties
+            not key.startswith('_') and
+            # Getter methods
+            not callable(value) and
+            # Objects that are generally not picklable
+            key not in ('cmdclass', 'distclass', 'ext_modules') and
+            # These *seem* useful but always have the value 0.
+            # Look for their values in the 'metadata' object instead.
+            key not in result.display_option_names
+        )
+    }

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,9 +1,12 @@
 apache
 chdir
 colcon
+distclass
 iterdir
+kwds
 noqa
 pathlib
+picklable
 plugin
 pytest
 pythonpath
@@ -11,4 +14,6 @@ rtype
 runpy
 scspell
 setuptools
+stacklevel
 thomas
+traceback

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,14 +2,15 @@ apache
 chdir
 colcon
 distclass
+functools
 iterdir
-kwds
 noqa
 pathlib
 picklable
 plugin
 pytest
 pythonpath
+recv
 rtype
 runpy
 scspell


### PR DESCRIPTION
Follow up to #22, #24

Adds and uses a new function wrapper `out_of_process` which wraps a python function into a subprocess.

Address some performance concerns by using multiprocessing.Process instead of multiprocessing.Pool when we’re not reusing the same pool.