### PR TITLE
add minimum version for flake8 to provide extend_ignore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
   setuptools
 packages = find:
 tests_require =
-  flake8
+  flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
   flake8-class-newline


### PR DESCRIPTION
We assume extend_ignore, which wasn’t introduced until 3.6.0