### PR TITLE
support non-realpath package path

### DIFF
--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -87,7 +87,7 @@ def get_setup_arguments(setup_py):
     global cwd_lock
     if not cwd_lock:
         cwd_lock = Lock()
-    setup_py = Path(str(setup_py))
+    setup_py = Path(str(setup_py)).resolve()
     assert setup_py.name == 'setup.py'
     # prevent side effects in other threads
     with cwd_lock:


### PR DESCRIPTION
Follow up of colcon/colcon-core#283. Fixes #29.

Since the code below the change changes the current working directory the package path (which can be relative since it is not the realpath anymore) must be resolved *before*.