### PR TITLE
Move SpecifierSet from setuptools to packaging

### DIFF
--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -248,7 +248,7 @@ def _get_setup_information(setup_py, *, env=None):
         'import sys',
         # setuptools needs to be imported before distutils
         # to avoid warning introduced in setuptools 49.2.0
-        'from setuptools.extern.packaging.specifiers import SpecifierSet',
+        'from packaging.specifiers import SpecifierSet',
         'from distutils.core import run_setup',
 
         'dist = run_setup('


### PR DESCRIPTION
`SpecifierSet` is moved from **setuptools 50.0.3** to **packaging 20.4** library. https://github.com/colcon/colcon-python-setup-py/issues/41