### PR TITLE
allow ImportError to support arch and older setuptools versions

### DIFF
--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -248,7 +248,14 @@ def _get_setup_information(setup_py, *, env=None):
         'import sys',
         # setuptools needs to be imported before distutils
         # to avoid warning introduced in setuptools 49.2.0
-        'from setuptools.extern.packaging.specifiers import SpecifierSet',
+        'from contextlib import suppress',
+        'exec("with suppress(ImportError):'
+        '    from setuptools.extern.packaging.specifiers'
+        '    import SpecifierSet")',
+        # newer versions expose 'packaging' directly
+        # on Arch 'extern' isn't part of the package
+        'exec("with suppress(ImportError):'
+        '    from packaging.specifiers import SpecifierSet")',
         'from distutils.core import run_setup',
 
         'dist = run_setup('


### PR DESCRIPTION
Follow up of #41 / #42.