### PR TITLE
Prepare 0.2.8 release.

### DIFF
--- a/colcon_python_setup_py/__init__.py
+++ b/colcon_python_setup_py/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2016-2020 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-__version__ = '0.2.7'
+__version__ = '0.2.8'


### PR DESCRIPTION
This release would close out the milestone here. https://github.com/colcon/colcon-python-setup-py/milestone/10

The pending PRs and issues all require some deliberation and I'd rather get #44 released as requested in #52 and rely on momentum to pick up the pending work.