### PR TITLE
Handle DISTUTILS_DEBUG environment variable

### DIFF
--- a/colcon_python_setup_py/package_identification/python_setup_py.py
+++ b/colcon_python_setup_py/package_identification/python_setup_py.py
@@ -212,6 +212,11 @@ def get_setup_arguments_with_context(setup_py, env):
 
     # invoke get_setup_arguments() in a separate interpreter
     cmd = [sys.executable, '-c', ';'.join(code_lines)]
+    if env is None:
+        env = os.environ
+    if 'DISTUTILS_DEBUG' in env:
+        env = dict(env)
+        env.pop('DISTUTILS_DEBUG')
     result = subprocess.run(
         cmd, stdout=subprocess.PIPE, env=env, check=True)
     output = result.stdout.decode('utf-8')
@@ -236,6 +241,9 @@ def get_setup_information(setup_py, *, env=None):
     global _setup_information_cache
     if env is None:
         env = os.environ
+    if 'DISTUTILS_DEBUG' in env:
+        env = dict(env)
+        env.pop('DISTUTILS_DEBUG')
     hashable_env = (setup_py, ) + tuple(sorted(env.items()))
     if hashable_env not in _setup_information_cache:
         _setup_information_cache[hashable_env] = _get_setup_information(


### PR DESCRIPTION
This variable causes setuptools/distutils to output more information to stdout than this extension is expecting to parse. Rather than update the parser to handle it, it's far more simple to simply suppress the verbose output during the calls which try to parse output.