### PR TITLE
Handle missing 'tests_require' option in newer setuptools

### DIFF
--- a/colcon_python_setup_py/package_augmentation/python_setup_py.py
+++ b/colcon_python_setup_py/package_augmentation/python_setup_py.py
@@ -44,7 +44,7 @@ class PythonPackageAugmentation(PackageAugmentationExtensionPoint):
         ]:
             desc.dependencies[dependency_type] = {
                 create_dependency_descriptor(d)
-                for d in config[option_name] or ()}
+                for d in config.get(option_name) or ()}
 
         def getter(env):
             nonlocal setup_py


### PR DESCRIPTION
This option was outright removed from newer versions of setuptools and is no longer visible at all. The existing behavior always raises an exception even if the unsupported option isn't used in the package.