### PR TITLE
Extract test dependencies from [options.extras_require]test

### DIFF
--- a/test/test_package_identification_python_setup_py.py
+++ b/test/test_package_identification_python_setup_py.py
@@ -73,6 +73,12 @@ def test_identify():
             "    'runB',\n"
             '  ],\n'
             '  zip_safe=False,\n'
+            '  extras_require={\n'
+            "    'test': ['test2 == 3.0.0'],\n"
+            "    'tests': ['test3'],\n"
+            "    'testing': ['test4'],\n"
+            "    'other': ['not-test'],\n"
+            '  },\n'
             ')\n')
         _setup_information_cache.clear()
         assert extension.identify(desc) is None
@@ -87,3 +93,4 @@ def test_identify():
         assert desc.dependencies['run'] == {'runA', 'runB'}
         dep = next(x for x in desc.dependencies['run'] if x == 'runA')
         assert dep.metadata['version_gt'] == '1.2.3'
+        assert desc.dependencies['test'] == {'test2', 'test3', 'test4'}


### PR DESCRIPTION
It's becoming an increasingly common pattern to declare test dependencies using [options.extras_require]test. This change merges the test dependencies declared using that mechanism with any discovered using [options]test_requires.

This change was made in `colcon-core` for `setup.cfg` projects in colcon/colcon-core#450 and released with `colcon-core` 0.7.0.